### PR TITLE
Simplify API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
       - checkout
       - run: cargo update
+      - run: cargo build
+      - run: cargo build --examples
       - run: cargo test
 workflows:
   version: 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "honeybadger"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Niel Drummond <niel@drummond.lu>"]
 description = "A Honeybadger client for rust"
 license = "MIT"
@@ -9,20 +9,19 @@ categories = ["api-bindings", "web-programming::http-client"]
 
 [dependencies]
 error-chain = "0.12.0"
-failure = "0.1.2"
-http = "0.1.7"
-hyper = "0.12.5"
-hyper-tls = "0.3.0"
+failure = "0.1.3"
+http = "0.1.14"
+hyper = "0.12.18"
+hyper-tls = "0.3.1"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-url = "1.2.2"
-backtrace = "0.3.9"
+url = "1.7.2"
+backtrace = "0.3.13"
 hostname = "0.1.5"
-os_type = "1.0.0"
-tokio = "0.1.7"
-native-tls = "0.2.0"
-futures = "0.1.21"
+os_type = "2.2.0"
+tokio = "=0.1.11"
+futures = "0.1.25"
 log = "0.4"
 
 [dev-dependencies]

--- a/examples/chained_error.rs
+++ b/examples/chained_error.rs
@@ -1,0 +1,38 @@
+//! Example that emits an error based on the chained_error crate, and sends it to honeybadger
+
+extern crate futures;
+extern crate honeybadger;
+extern crate tokio;
+#[macro_use]
+extern crate error_chain;
+
+error_chain! {
+  errors {
+    MyCustomError
+  }
+}
+
+use futures::future;
+use honeybadger::notice;
+use honeybadger::{ConfigBuilder, Honeybadger};
+use tokio::prelude::Future;
+use tokio::runtime::Runtime;
+
+fn main() {
+    let api_token = "ffffff";
+    let config = ConfigBuilder::new(api_token).build();
+    let honeybadger = Honeybadger::new(config).unwrap();
+
+    let mut rt = Runtime::new().unwrap();
+    let future = future::result(make_error())
+        .or_else(|e| honeybadger.notify(notice::Error::new(&e), None))
+        .map_err(|e| println!("{:?}", e));
+
+    rt.spawn(future);
+
+    rt.shutdown_on_idle().wait().unwrap();
+}
+
+fn make_error() -> Result<()> {
+    Err(ErrorKind::MyCustomError.into())
+}

--- a/examples/failure_error.rs
+++ b/examples/failure_error.rs
@@ -1,0 +1,36 @@
+//! Example that emits an error based on the chained_error crate, and sends it to honeybadger
+
+extern crate futures;
+extern crate honeybadger;
+extern crate tokio;
+
+#[macro_use]
+extern crate failure;
+
+#[derive(Fail, Debug)]
+#[fail(display = "Failure error")]
+struct MyCustomError;
+
+use futures::future;
+use honeybadger::{ConfigBuilder, Honeybadger};
+use tokio::prelude::Future;
+use tokio::runtime::Runtime;
+
+fn main() {
+    let api_token = "ffffff";
+    let config = ConfigBuilder::new(api_token).build();
+    let honeybadger = Honeybadger::new(config).unwrap();
+
+    let mut rt = Runtime::new().unwrap();
+    let future = future::result(make_error())
+        .or_else(|e| honeybadger.notify(e, None))
+        .map_err(|e| println!("{:?}", e));
+
+    rt.spawn(future);
+
+    rt.shutdown_on_idle().wait().unwrap();
+}
+
+fn make_error() -> Result<(), failure::Error> {
+    Err(MyCustomError {}.into())
+}

--- a/examples/std_error.rs
+++ b/examples/std_error.rs
@@ -1,0 +1,35 @@
+//! Example that emits a standard error, and sends it to honeybadger
+
+extern crate futures;
+extern crate honeybadger;
+extern crate tokio;
+
+use futures::future;
+use honeybadger::{ConfigBuilder, Honeybadger};
+use tokio::prelude::Future;
+use tokio::runtime::Runtime;
+
+use std::fs::File;
+
+fn main() {
+    let api_token = "ffffff";
+    let config = ConfigBuilder::new(api_token).build();
+    let honeybadger = Honeybadger::new(config).unwrap();
+
+    let mut rt = Runtime::new().unwrap();
+    let future = future::result(make_error())
+        .or_else(|e| {
+            let boxed: Box<std::error::Error> = e.into();
+            honeybadger.notify(boxed, None)
+        })
+        .map_err(|e| println!("{:?}", e));
+
+    rt.spawn(future);
+
+    rt.shutdown_on_idle().wait().unwrap();
+}
+
+fn make_error() -> Result<(), std::io::Error> {
+    File::create("/permission_denied")?;
+    Ok(())
+}


### PR DESCRIPTION
Add compatibility for `std::error::Error` and simplify API. Also add examples and better docs.