### PR TITLE
Don't peg tokio at 0.1.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "honeybadger"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Niel Drummond <niel@drummond.lu>"]
 description = "A Honeybadger client for rust"
 license = "MIT"
@@ -8,7 +8,7 @@ readme = "README.md"
 categories = ["api-bindings", "web-programming::http-client"]
 
 [dependencies]
-error-chain = "0.12.0"
+error-chain = "0.12.1"
 failure = "0.1.3"
 http = "0.1.14"
 hyper = "0.12.18"
@@ -20,8 +20,8 @@ url = "1.7.2"
 backtrace = "0.3.13"
 hostname = "0.1.5"
 os_type = "2.2.0"
-tokio = "=0.1.11"
-futures = "0.1.25"
+tokio = "0.1.15"
+futures = "0.1.27"
 log = "0.4"
 
 [dev-dependencies]


### PR DESCRIPTION
Needed to integrate with upstream projects that use a different tokio version.